### PR TITLE
compose file for running mongo in container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+
+/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: "mongodb"
+    environment:
+      - MONGO_DATA_DIR=/data/db
+      - MONGO_LOG_DIR=/dev/null
+    volumes:
+      - ./data/db:/data/db
+    ports:
+      - 27017:27017


### PR DESCRIPTION
This is just a docker compose file to have a mongo instance running in a container. It will still be available on 27017 just like a normal local version of mongo. This is just easier to manage and use later when we deploy. Also the backend will need a connection to a db to start.